### PR TITLE
HttpTest，支持添加context-path设置

### DIFF
--- a/src/main/java/io/github/cweijan/mock/context/HttpMockContext.java
+++ b/src/main/java/io/github/cweijan/mock/context/HttpMockContext.java
@@ -9,11 +9,20 @@ public class HttpMockContext {
     private final String scheme;
     private final String host;
     private final Integer port;
+    private final String contextPath;
 
     public HttpMockContext(String scheme, String host, Integer port) {
         this.scheme = scheme;
         this.host = host;
         this.port = port;
+        this.contextPath = "";
+    }
+
+    public HttpMockContext(String scheme, String host, Integer port, String contextPath) {
+        this.scheme = scheme;
+        this.host = host;
+        this.port = port;
+        this.contextPath = contextPath;
     }
 
     public String getScheme() {
@@ -28,4 +37,7 @@ public class HttpMockContext {
         return port;
     }
 
+    public String getContextPath() {
+        return contextPath;
+    }
 }

--- a/src/main/java/io/github/cweijan/mock/feign/parse/AbstractParser.java
+++ b/src/main/java/io/github/cweijan/mock/feign/parse/AbstractParser.java
@@ -13,10 +13,15 @@ public abstract class AbstractParser implements UrlParser {
     public String parse(HttpMockContext httpMockContext, Class<?> controllerClass) {
         return getScheme(httpMockContext, controllerClass) + "://" +
                 getHost(httpMockContext, controllerClass) +
+                getContextPath(httpMockContext, controllerClass) +
                 getPath(httpMockContext, controllerClass);
     }
 
     protected abstract String getPath(HttpMockContext httpMockContext, Class<?> controllerClass);
+
+    protected String getContextPath(HttpMockContext httpMockContext, Class<?> controllerClass) {
+        return httpMockContext.getContextPath();
+    }
 
     protected String getHost(HttpMockContext httpMockContext, Class<?> controllerClass) {
         return httpMockContext.getHost() + ":" + httpMockContext.getPort();

--- a/src/main/java/io/github/cweijan/mock/jupiter/HttpMockExtension.java
+++ b/src/main/java/io/github/cweijan/mock/jupiter/HttpMockExtension.java
@@ -1,6 +1,7 @@
 package io.github.cweijan.mock.jupiter;
 
 import ch.qos.logback.classic.LoggerContext;
+import io.github.cweijan.mock.context.HttpMockContext;
 import org.junit.jupiter.api.extension.*;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
@@ -43,12 +44,13 @@ public class HttpMockExtension implements ParameterResolver, TestInstancePostPro
 
     private void initContext(Object testInstance) {
         HttpTest httpTest = testInstance.getClass().getAnnotation(HttpTest.class);
-        this.mockInstanceHolder = new MockInstanceHolder(httpTest.scheme(), httpTest.host(), httpTest.port());
+        HttpMockContext context = new HttpMockContext(httpTest.scheme(), httpTest.host(), httpTest.port(), httpTest.contextPath());
+        this.mockInstanceHolder = new MockInstanceHolder(context);
     }
 
     private void disableLoggin() {
         ILoggerFactory iLoggerFactory = LoggerFactory.getILoggerFactory();
-        if(iLoggerFactory.getClass()== LoggerContext.class){
+        if (iLoggerFactory.getClass() == LoggerContext.class) {
             ((LoggerContext) iLoggerFactory).reset();
         }
     }
@@ -64,7 +66,7 @@ public class HttpMockExtension implements ParameterResolver, TestInstancePostPro
                     || declaredField.getDeclaredAnnotation(Resource.class) != null
                     || declaredField.getDeclaredAnnotation(Qualifier.class) != null) {
                 declaredField.setAccessible(true);
-                ReflectionUtils.setField(declaredField,o,mockInstanceHolder.getInstance(declaredField.getType()));
+                ReflectionUtils.setField(declaredField, o, mockInstanceHolder.getInstance(declaredField.getType()));
             }
         }
     }

--- a/src/main/java/io/github/cweijan/mock/jupiter/HttpTest.java
+++ b/src/main/java/io/github/cweijan/mock/jupiter/HttpTest.java
@@ -15,6 +15,10 @@ import java.lang.annotation.*;
 @ExtendWith(HttpMockExtension.class)
 public @interface HttpTest {
     String host() default "127.0.0.1";
+
     int port();
+
     String scheme() default "http";
+
+    String contextPath() default "";
 }

--- a/src/main/java/io/github/cweijan/mock/jupiter/MockInstanceHolder.java
+++ b/src/main/java/io/github/cweijan/mock/jupiter/MockInstanceHolder.java
@@ -13,18 +13,17 @@ import java.util.Map;
 public class MockInstanceHolder {
 
     private final HttpMockContext context;
-    private final Map<String,Object> instanceMap;
+    private final Map<String, Object> instanceMap = new HashMap<>();
 
-    public MockInstanceHolder(String scheme, String host, Integer port) {
-        this.context =new HttpMockContext(scheme, host, port);
-        this.instanceMap=new HashMap<>();
+    public MockInstanceHolder(HttpMockContext context) {
+        this.context = context;
     }
 
     @SuppressWarnings("unchecked")
-    public <T> T getInstance(Class<T> instanceClass){
+    public <T> T getInstance(Class<T> instanceClass) {
 
         return (T) instanceMap.computeIfAbsent(
-                instanceClass.getSimpleName()+"_"+ context.getScheme()+"_"+context.getHost()+"_"+context.getPort(),
+                instanceClass.getSimpleName() + "_" + context.getScheme() + "_" + context.getHost() + "_" + context.getPort(),
                 key -> Mocker.api(instanceClass, context)
         );
     }


### PR DESCRIPTION
我们项目有context-path设置，所以增加一个这个功能的支持

```
@HttpTest(host = "localhost", port = 8080,contextPath = "/context")
class ControllerTest {
    //do nothing
}
```